### PR TITLE
Add front test

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -80,6 +80,7 @@ jobs:
         env:
           ZENDESK_TOKEN: ${{secrets.ZENDESK_TOKEN}}
           RUST_BACKTRACE: 1
+          FRONT_API_TOKEN: ${{secrets.FRONT_API_TOKEN}}
 
           # TODO: turn back on coverage.
           #- name: Run cargo-tarpaulin

--- a/front/src/tests.rs
+++ b/front/src/tests.rs
@@ -27,7 +27,6 @@ async fn test_front_contacts() {
         assert_eq!(name, "test_name".to_string());
     }
     
-    // new_contact.name = Some("update_name".to_string());
     let contact_id = contact.id.unwrap();
     let updated_contact_body = crate::types::Contact {
         name: Some("update_name".to_string()),

--- a/front/src/tests.rs
+++ b/front/src/tests.rs
@@ -1,1 +1,55 @@
 
+use pretty_assertions::assert_eq;
+
+#[tokio::test]
+async fn test_front_contacts() {
+    let client = crate::Client::new_from_env();
+
+    let handles = vec![crate::types::ContactHandle {
+        source: crate::types::Source::Email,
+        handle: "test@buttz.com".to_string(),
+    }];
+
+    let new_contact = crate::types::CreateContact {
+        name: Some("test_name".to_string()),
+        description: None,
+        avatar: None,
+        is_spammer: None,
+        links: None,
+        group_names: None,
+        custom_fields: None,
+        handles: Some(handles),
+    };
+
+    let contact = client.contacts().create(&new_contact).await.unwrap();
+
+    if let Some(name) = contact.name {
+        assert_eq!(name, "test_name".to_string());
+    }
+    
+    // new_contact.name = Some("update_name".to_string());
+    let contact_id = contact.id.unwrap();
+    let updated_contact_body = crate::types::Contact {
+        name: Some("update_name".to_string()),
+        description: None,
+        avatar: None,
+        is_spammer: None,
+        links: None,
+        group_names: None,
+        custom_fields: None,
+    };
+    
+    client.contacts().update(&contact_id, &updated_contact_body).await;
+    let updated_contact = client.contacts().get(&contact_id).await.unwrap();
+    
+    if let Some(name) = updated_contact.name {
+        assert_eq!(name, "update_name".to_string());
+    }
+    
+    client.contacts().delete(&contact_id).await;
+    
+    let deleted_contact = client.contacts().get(&contact_id).await;
+
+    assert!(deleted_contact.is_err());
+
+}


### PR DESCRIPTION
Lol well this proves you library works fine 🚀 , so still need to figure out where the 400 was coming from.

But hey more tests are always good.

The tests will fail initially on the PR from a missing secret, @jessfraz could you give me permission for the repo or add `FRONT_API_TOKEN` to the secrets.

Is the tests at `front/src/tests.rs` okay, or will they get stomped by the next re-gen?

resolves #13
related to https://github.com/KittyCAD/PetStore/issues/48