### PR TITLE
Allow clippy warnings

### DIFF
--- a/.github/workflows/cargo-clippy.yml
+++ b/.github/workflows/cargo-clippy.yml
@@ -78,4 +78,4 @@ jobs:
           args: --all --exclude engine
       - name: Run clippy manually without annotations
         if: ${{ !steps.check_permissions.outputs.has-permission }}
-        run: cargo clippy --all -- -D warnings
+        run: cargo clippy --all


### PR DESCRIPTION
Generated code is never going to be implemented as beautifully and idiomatically as handwritten code. We should not fail CI just because our third party code manually implements Default instead of deriving it, or uses too many function arguments (sometimes APIs just have a lot of parameters, OK?)

If we wrote a beautiful handcrafted implementation of each API client, then sure, I'd fail on warnings. But if you're going to generate code, sometimes it will have some style faults.

openapitor actually runs `cargo clippy --fix` at the end of its generation step, so most clippy errors that can be easily fixed will be fixed, automatically. The remainder will be things like "too many arguments" which probably aren't worth failing on.

We can always revisit this once the third-party-api-clients repo passes CI again. At that point we should also pin the version of Rust it's using, so we don't start picking up new Clippy lints every 6 weeks and breaking CI.