### PR TITLE
Use fork of hyperx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,12 +113,6 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
@@ -230,7 +224,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes 1.2.1",
+ "bytes",
  "chrono",
  "chrono-humanize",
  "clap",
@@ -501,7 +495,7 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes 1.2.1",
+ "bytes",
  "chrono",
  "chrono-humanize",
  "clap",
@@ -644,7 +638,7 @@ version = "2.1.17"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes 1.2.1",
+ "bytes",
  "chrono",
  "chrono-humanize",
  "clap",
@@ -687,7 +681,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -733,7 +727,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "fnv",
  "itoa 1.0.3",
 ]
@@ -744,7 +738,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "http",
  "pin-project-lite",
 ]
@@ -767,7 +761,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -800,17 +794,14 @@ dependencies = [
 
 [[package]]
 name = "hyperx"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adce67e2c21cd95288ae3d9f2bbb2762cf17c03744628d49679f315ed1e2e58"
+version = "1.4.0"
+source = "git+https://github.com/KittyCAD/hyperx?branch=main#74335893f48479f541bb7cc261e29bd30e1616dd"
 dependencies = [
  "base64",
- "bytes 0.5.6",
+ "bytes",
  "http",
- "httparse",
  "httpdate",
  "language-tags",
- "log",
  "mime",
  "percent-encoding",
  "unicase",
@@ -915,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "language-tags"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -1360,7 +1351,7 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes 1.2.1",
+ "bytes",
  "chrono",
  "chrono-humanize",
  "clap",
@@ -1482,7 +1473,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes 1.2.1",
+ "bytes",
  "chrono",
  "chrono-humanize",
  "clap",
@@ -1526,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
  "base64",
- "bytes 1.2.1",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1681,7 +1672,7 @@ version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1847b767a3d62d95cbf3d8a9f0e421cf57a0d8aa4f411d4b16525afb0284d4ed"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "chrono",
  "dyn-clone",
  "schemars_derive",
@@ -2065,7 +2056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg",
- "bytes 1.2.1",
+ "bytes",
  "libc",
  "memchr",
  "mio",
@@ -2107,7 +2098,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2202,7 +2193,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes 1.2.1",
+ "bytes",
  "chrono",
  "chrono-humanize",
  "clap",

--- a/commonroom/Cargo.toml
+++ b/commonroom/Cargo.toml
@@ -20,7 +20,7 @@ dirs = { version = "^4.0.0", optional = true }
 format_serde_error = "^0.3.0"
 futures = "0.3.21"
 http = "^0.2.8"
-hyperx = "1"
+hyperx = { git = "https://github.com/KittyCAD/hyperx", branch = "main" }
 itertools = "^0.10.3"
 log = { version = "^0.4", features = ["serde"] }
 mime = "0.3"

--- a/front/Cargo.toml
+++ b/front/Cargo.toml
@@ -20,7 +20,7 @@ dirs = { version = "^4.0.0", optional = true }
 format_serde_error = "^0.3.0"
 futures = "0.3.21"
 http = "^0.2.8"
-hyperx = "1"
+hyperx = { git = "https://github.com/KittyCAD/hyperx", branch = "main" }
 itertools = "^0.10.3"
 log = { version = "^0.4", features = ["serde"] }
 mime = "0.3"

--- a/gusto/Cargo.toml
+++ b/gusto/Cargo.toml
@@ -20,7 +20,7 @@ dirs = { version = "^4.0.0", optional = true }
 format_serde_error = "^0.3.0"
 futures = "0.3.21"
 http = "^0.2.8"
-hyperx = "1"
+hyperx = { git = "https://github.com/KittyCAD/hyperx", branch = "main" }
 itertools = "^0.10.3"
 log = { version = "^0.4", features = ["serde"] }
 mime = "0.3"

--- a/mailchimp/Cargo.toml
+++ b/mailchimp/Cargo.toml
@@ -20,7 +20,7 @@ dirs = { version = "^4.0.0", optional = true }
 format_serde_error = "^0.3.0"
 futures = "0.3.21"
 http = "^0.2.8"
-hyperx = "1"
+hyperx = { git = "https://github.com/KittyCAD/hyperx", branch = "main" }
 itertools = "^0.10.3"
 log = { version = "^0.4", features = ["serde"] }
 mime = "0.3"

--- a/ramp/Cargo.toml
+++ b/ramp/Cargo.toml
@@ -20,7 +20,7 @@ dirs = { version = "^4.0.0", optional = true }
 format_serde_error = "^0.3.0"
 futures = "0.3.21"
 http = "^0.2.8"
-hyperx = "1"
+hyperx = { git = "https://github.com/KittyCAD/hyperx", branch = "main" }
 itertools = "^0.10.3"
 log = { version = "^0.4", features = ["serde"] }
 mime = "0.3"

--- a/remote/Cargo.toml
+++ b/remote/Cargo.toml
@@ -20,7 +20,7 @@ dirs = { version = "^4.0.0", optional = true }
 format_serde_error = "^0.3.0"
 futures = "0.3.26"
 http = "^0.2.8"
-hyperx = "1"
+hyperx = { git = "https://github.com/KittyCAD/hyperx", branch = "main" }
 itertools = "^0.10.3"
 log = { version = "^0.4", features = ["serde"] }
 mime = "0.3"

--- a/twilio/Cargo.toml
+++ b/twilio/Cargo.toml
@@ -20,7 +20,7 @@ dirs = { version = "^4.0.0", optional = true }
 format_serde_error = "^0.3.0"
 futures = "0.3.26"
 http = "^0.2.8"
-hyperx = "1"
+hyperx = { git = "https://github.com/KittyCAD/hyperx", branch = "main" }
 itertools = "^0.10.3"
 log = { version = "^0.4", features = ["serde"] }
 mime = "0.3"


### PR DESCRIPTION
This bypsses https://github.com/dekellum/hyperx/issues/39 which causes problems updating libraries in any repo that includes hyperx.

I have made a fork of hyperx under github.com/KittyCAD/hyperx -- Cloudflare did [the same thing](https://github.com/cloudflare/hyperx) for the same reason.